### PR TITLE
MOR-315: Fix accessibility issues with respect to the 'Logout' link

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -17,7 +17,7 @@
           My Community
         </b-nav-item>
         -->
-        <b-nav-item v-if="isLoggedIn" @click="logout" id="logout-nav-item">
+        <b-nav-item v-if="isLoggedIn" @click="logout" class="logout-nav-item">
           <b-icon-box-arrow-right aria-hidden="true"></b-icon-box-arrow-right>
           Logout
         </b-nav-item>
@@ -41,7 +41,7 @@
     border-bottom: 3px solid #84c661;
   }
 
-  nav #logout-nav-item a.nav-link {
+  nav#top .logout-nav-item a.nav-link {
     color: black
   }
 

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -18,7 +18,7 @@
         </b-nav-item>
         -->
         <b-nav-item v-if="isLoggedIn" @click="logout">
-          <b-icon-box-arrow-in-right></b-icon-box-arrow-in-right>
+          <b-icon-box-arrow-right aria-hidden="true"></b-icon-box-arrow-right>
           Logout
         </b-nav-item>
       </b-navbar-nav>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -17,7 +17,7 @@
           My Community
         </b-nav-item>
         -->
-        <b-nav-item v-if="isLoggedIn" @click="logout">
+        <b-nav-item v-if="isLoggedIn" @click="logout" id="logout-nav-item">
           <b-icon-box-arrow-right aria-hidden="true"></b-icon-box-arrow-right>
           Logout
         </b-nav-item>
@@ -41,9 +41,15 @@
     border-bottom: 3px solid #84c661;
   }
 
+  nav #logout-nav-item a.nav-link {
+    color: black
+  }
+
   .navbar-brand img {
     height: 2rem;
   }
+
+
 </style>
 
 <script>


### PR DESCRIPTION
This pull fixes two accessibility issues with the `Logout` link:

1. The name was including the label text associated with the `svg` image (box/arrow).  That was fixed using the technique of adding `aria-hidden="true"` to the markup, as advised by the [Bootstrap documentation](https://bootstrap-vue.org/docs/icons#working-with-svgs).
2. Added styles to increase the contrast of the `Logout` text to satisfy the WCAG requirement.

Also, I switched the icon used with the login from an arrow pointing _into_ the box to an arrow pointing _out_ of the box.  The latter is typically used with logging out, and leaving.

JIRA: https://morphic.atlassian.net/browse/MOR-315