### PR TITLE
MOR-310: Ensuring that the 'mode' button stays active looking after page changes

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -7,8 +7,8 @@
       </b-navbar-brand>
 
       <b-navbar-nav class="mr-auto">
-        <b-nav-item to="/dashboard/" v-if="isLoggedIn" exact-active-class="active"><b>Dashboard Mode</b></b-nav-item>
-        <b-nav-item to="/focused/home" v-if="isLoggedIn" exact-active-class="active"><b>Focus/Mobile Mode</b></b-nav-item>
+        <b-nav-item to="/dashboard/" :active="!focusMode" v-if="isLoggedIn" exact-active-class="active"><b>Dashboard Mode</b></b-nav-item>
+        <b-nav-item to="/focused/home" :active="focusMode" v-if="isLoggedIn" exact-active-class="active"><b>Focus/Mobile Mode</b></b-nav-item>
       </b-navbar-nav>
 
       <b-navbar-nav>
@@ -53,8 +53,10 @@ import { MESSAGES } from '@/utils/constants'
 export default {
   computed: {
     isLoggedIn: function () { return this.$store.getters.isLoggedIn },
-    disableLogout: function () { return this.$store.getters.unsavedChanges }
+    disableLogout: function () { return this.$store.getters.unsavedChanges },
+    focusMode: function () { return this.$route.path.includes("/focused/") }
   },
+
   methods: {
     logout: function () {
       if (this.disableLogout) {


### PR DESCRIPTION
Title says it all... Before the marking of which mode the user is in would disappear once any link was clicked.

This fix assumes that all URLs in focused mode will contain "focused" in its path