### PR TITLE
MOR-325:  Switch console.err() to console.error()

### DIFF
--- a/src/components/dashboard/BarPreview.vue
+++ b/src/components/dashboard/BarPreview.vue
@@ -79,7 +79,7 @@ export default {
           this.bar = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     } else {
       // the data comes in the bar prop

--- a/src/components/dashboard/DrawerPreview.vue
+++ b/src/components/dashboard/DrawerPreview.vue
@@ -74,7 +74,7 @@ export default {
         this.bar = resp.data
       })
       .catch(err => {
-        console.err(err)
+        console.error(err)
       })
   }
 }

--- a/src/components/dashboard/RenderList.vue
+++ b/src/components/dashboard/RenderList.vue
@@ -57,7 +57,7 @@ export default {
         }
       })
       .catch(err => {
-        console.err(err)
+        console.error(err)
       })
   }
 }

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -215,11 +215,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     autoHideDetails: function (data, showFirstOne) {

--- a/src/views/MemberEditor.vue
+++ b/src/views/MemberEditor.vue
@@ -144,7 +144,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getMemberBar () {
@@ -153,7 +153,7 @@ export default {
           this.currentMorphicBar = resp.data.id
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },
@@ -170,7 +170,7 @@ export default {
           this.getMemberBar()
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   }

--- a/src/views/MemberInvite.vue
+++ b/src/views/MemberInvite.vue
@@ -239,7 +239,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     attachBar (resp) {
@@ -254,7 +254,7 @@ export default {
           this.$router.push('/dashboard')
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },
@@ -269,7 +269,7 @@ export default {
         this.selectedBar = this.bars[0].id
       })
       .catch(err => {
-        console.err(err)
+        console.error(err)
       })
   }
 }

--- a/src/views/MorphicBarEditor.vue
+++ b/src/views/MorphicBarEditor.vue
@@ -815,7 +815,7 @@ export default {
             this.originalBarDetails = JSON.parse(JSON.stringify(this.barDetails));
           })
           .catch(err => {
-            console.err(err)
+            console.error(err)
           })
       }
     },
@@ -846,7 +846,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     changeMemberRole: function () {
@@ -863,7 +863,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     updateOriginalBarDetails: function () {
@@ -897,12 +897,12 @@ export default {
                   }
                 })
                 .catch(err => {
-                  console.err(err)
+                  console.error(err)
                 })
             }
           })
           .catch(err => {
-            console.err(err)
+            console.error(err)
           })
       } else {
         this.saveBar()
@@ -930,7 +930,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     saveBar: function () {
@@ -953,7 +953,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     deleteBar: function () {
@@ -968,7 +968,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     expandCatalogButton: function (button, buttonId) {
@@ -1029,11 +1029,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getBarRemoveValidity: function () {
@@ -1048,7 +1048,7 @@ export default {
           this.memberDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getCommunityData: function () {
@@ -1057,7 +1057,7 @@ export default {
           this.community = community.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     generateId: function (item) {

--- a/src/views/MyCommunity.vue
+++ b/src/views/MyCommunity.vue
@@ -76,7 +76,7 @@ export default {
         this.communities = resp.data.communities
       })
       .catch(err => {
-        console.err(err)
+        console.error(err)
       })
   },
   methods: {
@@ -92,7 +92,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   }

--- a/src/views/focused/FocusedBarEditor.vue
+++ b/src/views/focused/FocusedBarEditor.vue
@@ -162,7 +162,7 @@ export default {
     //       }
     //     })
     //     .catch(err => {
-    //       console.err(err)
+    //       console.error(err)
     //     })
     // },
     // changeUserRole: function () {
@@ -179,7 +179,7 @@ export default {
     //       }
     //     })
     //     .catch(err => {
-    //       console.err(err)
+    //       console.error(err)
     //     })
     // },
     addPersonalBar: function () {
@@ -209,12 +209,12 @@ export default {
                   }
                 })
                 .catch(err => {
-                  console.err(err)
+                  console.error(err)
                 })
             }
           })
           .catch(err => {
-            console.err(err)
+            console.error(err)
           })
       } else {
         this.saveBar()
@@ -238,7 +238,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     saveBar: function () {
@@ -259,7 +259,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     deleteBar: function () {
@@ -274,7 +274,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     // predefinedClicked: function (event, index, makeAButtons) {
@@ -442,11 +442,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getBarRemoveValidity: function () {
@@ -461,7 +461,7 @@ export default {
           this.memberDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getCommunityData: function() {
@@ -470,7 +470,7 @@ export default {
           this.community = community.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     generateId: function(item) {
@@ -526,7 +526,7 @@ export default {
           this.barDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
     if (this.$route.query.memberId) {
@@ -626,7 +626,7 @@ export default {
           this.getCommunityData()
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },

--- a/src/views/focused/FocusedBarSettings.vue
+++ b/src/views/focused/FocusedBarSettings.vue
@@ -133,7 +133,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     changeUserRole: function () {
@@ -150,7 +150,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     addPersonalBar: function () {
@@ -180,12 +180,12 @@ export default {
                   }
                 })
                 .catch(err => {
-                  console.err(err)
+                  console.error(err)
                 })
             }
           })
           .catch(err => {
-            console.err(err)
+            console.error(err)
           })
       } else {
         this.saveBar()
@@ -209,7 +209,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     saveBar: function () {
@@ -230,7 +230,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     deleteBar: function () {
@@ -245,7 +245,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     predefinedClicked: function (event, index, makeAButtons) {
@@ -413,11 +413,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getBarRemoveValidity: function () {
@@ -432,7 +432,7 @@ export default {
           this.memberDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getCommunityData: function() {
@@ -441,7 +441,7 @@ export default {
           this.community = community.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     generateId: function(item) {
@@ -497,7 +497,7 @@ export default {
           this.barDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
     if (this.$route.query.memberId) {
@@ -597,7 +597,7 @@ export default {
           this.getCommunityData()
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },

--- a/src/views/focused/FocusedButtonCatalog.vue
+++ b/src/views/focused/FocusedButtonCatalog.vue
@@ -109,7 +109,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },
@@ -143,7 +143,7 @@ export default {
           this.barDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
     if (this.$route.query.memberId) {
@@ -235,7 +235,7 @@ export default {
           this.getCommunityData()
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },

--- a/src/views/focused/FocusedButtonEdit.vue
+++ b/src/views/focused/FocusedButtonEdit.vue
@@ -120,7 +120,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     changeUserRole: function () {
@@ -137,7 +137,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     addPersonalBar: function () {
@@ -167,12 +167,12 @@ export default {
                   }
                 })
                 .catch(err => {
-                  console.err(err)
+                  console.error(err)
                 })
             }
           })
           .catch(err => {
-            console.err(err)
+            console.error(err)
           })
       } else {
         this.saveBar()
@@ -196,7 +196,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     saveBar: function () {
@@ -217,7 +217,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     deleteBar: function () {
@@ -232,7 +232,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     predefinedClicked: function (event, index, makeAButtons) {
@@ -400,11 +400,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getBarRemoveValidity: function () {
@@ -419,7 +419,7 @@ export default {
           this.memberDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getCommunityData: function() {
@@ -428,7 +428,7 @@ export default {
           this.community = community.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     generateId: function(item) {
@@ -484,7 +484,7 @@ export default {
           this.barDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
     if (this.$route.query.memberId) {
@@ -584,7 +584,7 @@ export default {
           this.getCommunityData()
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },

--- a/src/views/focused/FocusedHome.vue
+++ b/src/views/focused/FocusedHome.vue
@@ -163,11 +163,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     autoHideDetails: function (data, showFirstOne) {

--- a/src/views/focused/FocusedPeopleUsingBar.vue
+++ b/src/views/focused/FocusedPeopleUsingBar.vue
@@ -128,7 +128,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     changeUserRole: function () {
@@ -145,7 +145,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     addPersonalBar: function () {
@@ -175,12 +175,12 @@ export default {
                   }
                 })
                 .catch(err => {
-                  console.err(err)
+                  console.error(err)
                 })
             }
           })
           .catch(err => {
-            console.err(err)
+            console.error(err)
           })
       } else {
         this.saveBar()
@@ -204,7 +204,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     saveBar: function () {
@@ -225,7 +225,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     deleteBar: function () {
@@ -240,7 +240,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     predefinedClicked: function (event, index, makeAButtons) {
@@ -408,11 +408,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getBarRemoveValidity: function () {
@@ -427,7 +427,7 @@ export default {
           this.memberDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getCommunityData: function() {
@@ -436,7 +436,7 @@ export default {
           this.community = community.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     generateId: function(item) {
@@ -492,7 +492,7 @@ export default {
           this.barDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
     if (this.$route.query.memberId) {
@@ -592,7 +592,7 @@ export default {
           this.getCommunityData()
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },

--- a/src/views/focused/FocusedPersonPage.vue
+++ b/src/views/focused/FocusedPersonPage.vue
@@ -132,7 +132,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     changeUserRole: function () {
@@ -149,7 +149,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     addPersonalBar: function () {
@@ -179,12 +179,12 @@ export default {
                   }
                 })
                 .catch(err => {
-                  console.err(err)
+                  console.error(err)
                 })
             }
           })
           .catch(err => {
-            console.err(err)
+            console.error(err)
           })
       } else {
         this.saveBar()
@@ -208,7 +208,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     saveBar: function () {
@@ -229,7 +229,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     deleteBar: function () {
@@ -244,7 +244,7 @@ export default {
           }
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     predefinedClicked: function (event, index, makeAButtons) {
@@ -418,11 +418,11 @@ export default {
               }
             })
             .catch(err => {
-              console.err(err)
+              console.error(err)
             })
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getBarRemoveValidity: function () {
@@ -437,7 +437,7 @@ export default {
           this.memberDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     getCommunityData: function() {
@@ -446,7 +446,7 @@ export default {
           this.community = community.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     },
     generateId: function(item) {
@@ -502,7 +502,7 @@ export default {
           this.barDetails = resp.data
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
     if (this.$route.query.memberId) {
@@ -602,7 +602,7 @@ export default {
           this.getCommunityData()
         })
         .catch(err => {
-          console.err(err)
+          console.error(err)
         })
     }
   },


### PR DESCRIPTION
Hi @javihernandez While working on other aspects of the webapp and looking at logged messages, I noticed a number of `Uncaught (in promise) TypeError: console.err is not a function` errors.  As far as I can tell, the function should be `console.error`.  It took almost no time to do a global search and replace.  This pull fixes them all.

JIRA: https://morphic.atlassian.net/browse/MOR-322